### PR TITLE
feat: add "The Reveal" — a gender-reveal game mode 🍼🎀

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This recreation includes:
 - **5 hand-crafted levels** of increasing difficulty
 - **2D mode** — classic top-down tile view
 - **3D mode** — first-person raycasting perspective (Wolfenstein-style)
+- **The Reveal mode** 🍼🎀 — a special baby-themed surprise mission: guide the Big Brother through three nursery stages, dodge runaway toys, collect baby bottles, and pop the mystery balloon at the end to discover the family's big secret!
 - Enemies (bugs, tanks, balls, gliders) with authentic movement logic
 - Keys and colored doors
 - Ice, water, fire, and force-floor tiles with matching boot pickups
@@ -62,7 +63,8 @@ Alternatively, open `index.html` directly in your browser (most features work wi
 │   └── style.css       # Retro dark theme styles
 └── js/
     ├── game.js         # Game logic, 2D renderer, level data, entities
-    └── renderer3d.js   # First-person 3D raycasting renderer
+    ├── renderer3d.js   # First-person 3D raycasting renderer
+    └── reveal.js       # "The Reveal" surprise mode: nursery levels, pastel renderer, celebration
 ```
 
 ---

--- a/css/style.css
+++ b/css/style.css
@@ -132,6 +132,190 @@ html, body {
   box-shadow: 0 6px 20px rgba(170,0,255,0.6);
 }
 
+/* ── The Reveal: title-screen button ─────────────────────── */
+.reveal-select {
+  margin-top: 16px;
+}
+
+.reveal-tagline {
+  color: #f0a8c8;
+  font-size: 12px;
+  letter-spacing: 1px;
+  margin-top: 10px;
+}
+
+.btn-reveal {
+  background: linear-gradient(90deg, #ff8fb3 0%, #ffb6d9 35%, #a8d4ff 65%, #6cb4ff 100%);
+  color: #3a1030;
+  box-shadow: 0 4px 16px rgba(255,143,179,0.5);
+  animation: reveal-pulse 1.6s ease-in-out infinite;
+}
+.btn-reveal:hover, .btn-reveal:focus {
+  background: linear-gradient(90deg, #ffa8c4 0%, #ffc8e4 35%, #bce0ff 65%, #88c4ff 100%);
+  box-shadow: 0 6px 24px rgba(255,143,179,0.8);
+}
+
+@keyframes reveal-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.05); }
+}
+
+/* ── The Reveal: secret screen ───────────────────────────── */
+#reveal-screen {
+  position: relative;
+}
+#reveal-screen.active {
+  display: block;
+  background: linear-gradient(160deg, #2a1030 0%, #3a1840 40%, #1a2a4a 100%);
+  min-height: 100vh;
+}
+
+#confetti-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.reveal-content {
+  position: relative;
+  z-index: 10;
+}
+
+.reveal-phase {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+.reveal-phase.hidden { display: none; }
+
+#reveal-intro h2,
+#reveal-balloon-phase h2 {
+  color: #ffb6d9;
+  text-shadow: 0 0 16px rgba(255,143,179,0.6);
+}
+
+/* Countdown numbers */
+#reveal-countdown {
+  font-size: 110px;
+  font-weight: bold;
+  color: #ffd700;
+  text-shadow: 0 0 30px rgba(255,215,0,0.8);
+  min-height: 130px;
+  line-height: 130px;
+}
+#reveal-countdown.count-pop {
+  animation: count-pop 0.9s ease-out;
+}
+@keyframes count-pop {
+  0%   { transform: scale(0.2); opacity: 0; }
+  40%  { transform: scale(1.3); opacity: 1; }
+  100% { transform: scale(1);   opacity: 0.9; }
+}
+
+/* The mystery balloon */
+#reveal-balloon {
+  width: 140px;
+  height: 170px;
+  margin-top: 20px;
+  background: radial-gradient(circle at 35% 30%, #d8b8ff 0%, #aa66ee 55%, #7a3ab8 100%);
+  border-radius: 50% 50% 50% 50% / 55% 55% 45% 45%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  position: relative;
+  transition: transform 0.12s ease-out;
+  animation: balloon-float 2.2s ease-in-out infinite;
+  box-shadow: 0 8px 40px rgba(170,102,238,0.5);
+}
+#reveal-balloon::after {
+  /* balloon string */
+  content: '';
+  position: absolute;
+  bottom: -56px;
+  left: 50%;
+  width: 2px;
+  height: 56px;
+  background: rgba(255,255,255,0.6);
+}
+#reveal-balloon span {
+  font-size: 64px;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: 0 0 16px rgba(255,255,255,0.8);
+  pointer-events: none;
+}
+#reveal-balloon.popped {
+  animation: balloon-pop 0.45s ease-out forwards;
+}
+@keyframes balloon-float {
+  0%, 100% { margin-top: 20px; }
+  50%      { margin-top: 6px; }
+}
+@keyframes balloon-pop {
+  0%   { transform: scale(2.1);  opacity: 1; }
+  30%  { transform: scale(2.6);  opacity: 1; }
+  100% { transform: scale(3.4);  opacity: 0; }
+}
+
+/* The big secret */
+.reveal-bow {
+  font-size: 72px;
+  animation: bounce 1s ease infinite alternate;
+}
+
+#reveal-headline {
+  font-size: clamp(40px, 12vw, 72px);
+  color: #ff69b4;
+  letter-spacing: 4px;
+  text-shadow: 0 0 24px rgba(255,105,180,0.9), 0 0 60px rgba(255,105,180,0.5);
+  animation: headline-in 0.8s cubic-bezier(0.18, 0.89, 0.32, 1.28) both;
+}
+
+/* Scoped under #reveal-screen so these out-rank the generic
+   .overlay-content p rule without needing !important */
+#reveal-screen .reveal-message {
+  font-size: 20px;
+  color: #ffd8ea;
+  max-width: none;
+  line-height: 1.8;
+  animation: fade-up 0.8s ease-out 0.6s both;
+}
+#reveal-screen .reveal-message span {
+  font-size: clamp(28px, 8vw, 44px);
+  font-weight: bold;
+  color: #ffb6d9;
+  text-shadow: 0 0 20px rgba(255,143,179,0.8);
+  letter-spacing: 3px;
+}
+
+#reveal-screen .reveal-congrats {
+  font-size: 16px;
+  color: #f0c8dc;
+  animation: fade-up 0.8s ease-out 1.4s both;
+}
+
+#reveal-home-btn {
+  animation: fade-up 0.8s ease-out 2.2s both;
+}
+
+@keyframes headline-in {
+  0%   { transform: scale(0.1) rotate(-8deg); opacity: 0; }
+  100% { transform: scale(1)   rotate(0);     opacity: 1; }
+}
+
+@keyframes fade-up {
+  0%   { transform: translateY(24px); opacity: 0; }
+  100% { transform: translateY(0);    opacity: 1; }
+}
+
 /* ── HUD ─────────────────────────────────────────────── */
 #hud {
   display: flex;
@@ -359,8 +543,11 @@ html, body {
   }
 
   /* Square game screen: as wide as the viewport height (tallest square
-     that fits both dimensions), centered horizontally */
-  #game-screen {
+     that fits both dimensions), centered horizontally.
+     Scoped to .active so the game screen stays hidden behind other screens
+     (title, win, reveal, ...) — the bare #game-screen selector would
+     out-rank the .screen display:none rule. */
+  #game-screen.active {
     display: flex;
     flex-direction: column;
     height: 100vh;

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
           <button id="start-2d-btn" class="btn-primary">▶ PLAY 2D</button>
           <button id="start-3d-btn" class="btn-primary btn-3d">▶ PLAY 3D</button>
         </div>
+        <div class="mode-select reveal-select">
+          <button id="start-reveal-btn" class="btn-primary btn-reveal">🍼 THE REVEAL 🎀</button>
+        </div>
+        <p class="reveal-tagline">A special surprise mission for the Big Brother...</p>
         <div class="controls-hint">
           <p>2D mode: Arrow Keys / WASD to move in any direction</p>
           <p>3D mode: ↑↓ Move forward/back &nbsp;·&nbsp; ←→ Turn</p>
@@ -42,7 +46,7 @@
             <div id="hud-time" class="hud-value">---</div>
           </div>
           <div class="hud-block">
-            <div class="hud-label">CHIPS LEFT</div>
+            <div class="hud-label" id="hud-chips-label">CHIPS LEFT</div>
             <div id="hud-chips" class="hud-value">0</div>
           </div>
         </div>
@@ -122,9 +126,42 @@
       </div>
     </div>
 
+    <!-- The Reveal — Big Secret Screen -->
+    <div id="reveal-screen" class="screen">
+      <canvas id="confetti-canvas"></canvas>
+      <div class="overlay-content reveal-content">
+
+        <!-- Phase 1: countdown -->
+        <div id="reveal-intro" class="reveal-phase">
+          <div class="overlay-icon">💌</div>
+          <h2>YOU DID IT, BIG BROTHER!</h2>
+          <p>The stork has a special delivery for your family...</p>
+          <div id="reveal-countdown"></div>
+        </div>
+
+        <!-- Phase 2: pop the mystery balloon -->
+        <div id="reveal-balloon-phase" class="reveal-phase hidden">
+          <h2>POP THE MYSTERY BALLOON!</h2>
+          <p>Tap it as fast as you can!</p>
+          <div id="reveal-balloon"><span>?</span></div>
+        </div>
+
+        <!-- Phase 3: the big secret -->
+        <div id="reveal-final-phase" class="reveal-phase hidden">
+          <div class="reveal-bow">🎀</div>
+          <h1 id="reveal-headline">IT'S A GIRL!</h1>
+          <p class="reveal-message">You're going to have a<br><span>BABY&nbsp;SISTER!</span></p>
+          <p class="reveal-congrats">Congratulations, Big Brother! 👶💕</p>
+          <button id="reveal-home-btn" class="btn-primary btn-reveal">💖 BACK TO TITLE 💖</button>
+        </div>
+
+      </div>
+    </div>
+
   </div>
 
   <script src="js/game.js"></script>
   <script src="js/renderer3d.js"></script>
+  <script src="js/reveal.js"></script>
 </body>
 </html>

--- a/js/game.js
+++ b/js/game.js
@@ -604,6 +604,9 @@ class Renderer {
     this.ts     = TILE_SIZE;
     this.canvas.width  = VIEW_W * this.ts;
     this.canvas.height = VIEW_H * this.ts;
+    // Instance-level palettes so themed renderers (e.g. The Reveal) can override them
+    this.keyColors  = KEY_COLORS;
+    this.doorColors = DOOR_COLORS;
   }
 
   draw(game) {
@@ -1001,7 +1004,7 @@ class Renderer {
 
   _drawKey(ctx, tile, sx, sy) {
     const ts = this.ts;
-    const col = KEY_COLORS[tile] || '#fff';
+    const col = this.keyColors[tile] || '#fff';
     // Background circle
     ctx.fillStyle = 'rgba(0,0,0,0.3)';
     ctx.beginPath();
@@ -1027,7 +1030,7 @@ class Renderer {
 
   _drawDoor(ctx, tile, sx, sy) {
     const ts = this.ts;
-    const col = DOOR_COLORS[tile] || '#888';
+    const col = this.doorColors[tile] || '#888';
     // Door frame
     ctx.fillStyle = col;
     ctx.fillRect(sx + 3, sy, ts - 6, ts);
@@ -1265,6 +1268,19 @@ class AudioManager {
   bump()         { this._beep(110, 0.05, 'sawtooth', 0.08); }
   pickupItem()   { this._beep(660, 0.1, 'triangle', 0.12); }
   splash()       { this._beep(300, 0.15, 'sawtooth', 0.1); }
+
+  // ── The Reveal mode sounds ──
+  countdownBeep()   { this._beep(440, 0.2, 'sine', 0.2); }
+  balloonTap(step)  { this._beep(330 + step * 90, 0.12, 'sine', 0.2); }
+  balloonPop()      { this._beep(120, 0.25, 'sawtooth', 0.3); setTimeout(() => this._beep(80, 0.3, 'square', 0.2), 60); }
+  revealFanfare()   {
+    const notes = [523, 523, 523, 659, 784, 784, 1047];
+    const times = [0, 150, 300, 450, 700, 900, 1150];
+    notes.forEach((freq, i) => {
+      const len = i === notes.length - 1 ? 0.7 : 0.18;
+      setTimeout(() => this._beep(freq, len, 'triangle', 0.22), times[i]);
+    });
+  }
 }
 
 // ============================================================
@@ -1293,6 +1309,9 @@ class Game {
   constructor() {
     this.currentLevel = 0;
     this.gameMode     = '2d';   // '2d' or '3d'
+    this.levelSet     = LEVELS; // active level set (LEVELS or REVEAL_LEVELS)
+    this.revealMode   = false;  // true when playing "The Reveal" surprise mode
+    this._confetti    = null;   // confetti show running on the reveal screen
     this.audio        = new AudioManager();
     this.renderer     = null;
     this.running      = false;
@@ -1310,7 +1329,7 @@ class Game {
   // ── Initialise / Load Level ────────────────────────────────
 
   loadLevel(index) {
-    const def = LEVELS[index];
+    const def = this.levelSet[index];
 
     // Deep copy the map so we can mutate it
     this.map   = def.map.map(row => [...row]);
@@ -1382,7 +1401,10 @@ class Game {
     } else {
       el('hud-time').textContent = '∞';
     }
-    el('level-title-text').textContent = `Level ${def.number}: ${def.title}`;
+    el('hud-chips-label').textContent = this.revealMode ? 'BOTTLES LEFT' : 'CHIPS LEFT';
+    el('level-title-text').textContent = this.revealMode
+      ? `The Reveal — Stage ${def.number}: ${def.title}`
+      : `Level ${def.number}: ${def.title}`;
     this._refreshInventoryHUD();
     this._hideHint();
   }
@@ -1391,11 +1413,12 @@ class Game {
     // Keys
     const keysEl = document.getElementById('hud-keys');
     keysEl.innerHTML = '';
+    const keyColors = (this.renderer && this.renderer.keyColors) || KEY_COLORS;
     for (const [tile, count] of Object.entries(this.inventory.keys)) {
       for (let i = 0; i < count; i++) {
         const div = document.createElement('div');
         div.className = 'inv-item';
-        div.style.background = KEY_COLORS[tile] || '#888';
+        div.style.background = keyColors[tile] || '#888';
         div.textContent = 'K';
         keysEl.appendChild(div);
       }
@@ -1743,7 +1766,10 @@ class Game {
 
   _killPlayer(msg) {
     this.dead     = true;
-    this.deathMsg = msg;
+    // In The Reveal every hazard is a runaway toy — keep it friendly!
+    this.deathMsg = this.revealMode
+      ? 'A runaway toy caught Shmo! Try again, Big Brother — the secret is waiting!'
+      : msg;
     this.audio.death();
   }
 
@@ -1906,7 +1932,7 @@ class Game {
   _showHint() {
     const banner  = document.getElementById('hint-banner');
     const textEl  = document.getElementById('hint-text');
-    textEl.textContent = LEVELS[this.currentLevel].hint;
+    textEl.textContent = this.levelSet[this.currentLevel].hint;
     banner.classList.remove('hidden');
   }
 
@@ -1992,13 +2018,20 @@ class Game {
 
     if (this.won && !this._winHandled) {
       this._winHandled = true;
-      const isLast = this.currentLevel >= LEVELS.length - 1;
+      const isLast = this.currentLevel >= this.levelSet.length - 1;
       setTimeout(() => {
         if (isLast) {
-          this._showScreen('complete-screen');
+          if (this.revealMode) {
+            // The final stage of The Reveal leads to the big secret!
+            startRevealCelebration(this);
+          } else {
+            this._showScreen('complete-screen');
+          }
         } else {
-          document.getElementById('win-msg').textContent =
-            `Level ${LEVELS[this.currentLevel].number} complete!`;
+          const def = this.levelSet[this.currentLevel];
+          document.getElementById('win-msg').textContent = this.revealMode
+            ? `Stage ${def.number} complete! The big secret is getting closer...`
+            : `Level ${def.number} complete!`;
           this._showScreen('win-screen');
         }
       }, 400);
@@ -2019,14 +2052,20 @@ class Game {
     const canvas = document.getElementById('game-canvas');
 
     // Shared helper: begin playing in the given mode from level 0.
+    // Modes: '2d', '3d', or 'reveal' (The Reveal — top-down with its own
+    // level set, pastel renderer, and surprise ending).
     const _startGame = (mode) => {
       // Clear any stale input state accumulated while on the title screen.
       this.keysHeld.clear();
       this.queuedDir = null;
       this.lastMove  = 0;
 
-      this.gameMode  = mode;
-      this.renderer  = mode === '3d' ? new Renderer3D(canvas) : new Renderer(canvas);
+      this.revealMode = mode === 'reveal';
+      this.levelSet   = this.revealMode ? REVEAL_LEVELS : LEVELS;
+      this.gameMode   = mode === '3d' ? '3d' : '2d';
+      this.renderer   = mode === '3d'    ? new Renderer3D(canvas)
+                      : this.revealMode  ? new RendererReveal(canvas)
+                      :                    new Renderer(canvas);
       this.audio._resume();
       this.currentLevel  = 0;
       this._deathHandled = false;
@@ -2042,6 +2081,7 @@ class Game {
     // Mode-select buttons on the title screen.
     document.getElementById('start-2d-btn').addEventListener('click', () => _startGame('2d'));
     document.getElementById('start-3d-btn').addEventListener('click', () => _startGame('3d'));
+    document.getElementById('start-reveal-btn').addEventListener('click', () => _startGame('reveal'));
 
     document.getElementById('next-level-btn').addEventListener('click', () => {
       this.currentLevel++;
@@ -2059,15 +2099,20 @@ class Game {
     document.getElementById('timeout-retry-btn').addEventListener('click', () => this._retryLevel());
 
     // "Play Again" returns to the title screen so the player can re-choose mode.
-    document.getElementById('play-again-btn').addEventListener('click', () => {
-      if (this.rafId) { cancelAnimationFrame(this.rafId); this.rafId = null; }
-      this.running = false;
-      // Clear input state so no key-press leaks into the next game start.
-      this.keysHeld.clear();
-      this.queuedDir = null;
-      this.lastMove  = 0;
-      this._showScreen('title-screen');
-    });
+    document.getElementById('play-again-btn').addEventListener('click', () => this._returnToTitle());
+  }
+
+  // Stop the game loop, clear input state, and show the title screen.
+  // Used by the "play again" button and The Reveal's "back to title" button.
+  _returnToTitle() {
+    if (this.rafId) { cancelAnimationFrame(this.rafId); this.rafId = null; }
+    this.running = false;
+    if (this._confetti) { this._confetti.stop(); this._confetti = null; }
+    // Clear input state so no key-press leaks into the next game start.
+    this.keysHeld.clear();
+    this.queuedDir = null;
+    this.lastMove  = 0;
+    this._showScreen('title-screen');
   }
 
   _retryLevel() {
@@ -2088,5 +2133,6 @@ class Game {
 
 window.addEventListener('DOMContentLoaded', () => {
   const game = new Game();
+  window.shmoGame = game;   // exposed for debugging / automated tests
   game.start();
 });

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1,0 +1,494 @@
+'use strict';
+
+// ============================================================
+//  THE REVEAL — a special surprise game mode
+//
+//  Shmo (the Big Brother) journeys through three nursery-themed
+//  stages collecting baby bottles.  Beat the final stage, pop the
+//  mystery balloon, and discover the big family secret!
+//
+//  Loaded after game.js (uses T, E, D, _copyMap, Renderer, KEY_COLORS,
+//  DOOR_COLORS) and is referenced by Game when mode === 'reveal'.
+// ============================================================
+
+// ────────────────────────────────────────────────────────────
+//  STAGE MAPS  (16×16, same tile IDs as the main game)
+// ────────────────────────────────────────────────────────────
+
+// ── STAGE 1: Welcome to the Nursery ─────────────────────────
+// Two cosy nursery rooms joined by corridors.  6 bottles, no
+// runaway toys yet, no time limit.  Hint tile right next to the
+// start so the player learns the goal.
+const _R1_MAP = [
+  //col: 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+  /*r0*/  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  /*r1*/  [1, 0,23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // hint @ (2,1)
+  /*r2*/  [1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1],  // gap @ c3 & c12
+  /*r3*/  [1, 1, 1, 0, 2, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1],  // bottles @ (4,3) (11,3)
+  /*r4*/  [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],  // upper nursery
+  /*r5*/  [1, 1, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 1, 1, 1],  // bottle @ (7,5)
+  /*r6*/  [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1],  // gap @ c7 & c8
+  /*r7*/  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // hallway
+  /*r8*/  [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1],  // gap @ c7 & c8
+  /*r9*/  [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],  // lower nursery
+  /*r10*/ [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+  /*r11*/ [1, 1, 1, 0, 2, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1],  // bottles @ (4,11)(11,11)
+  /*r12*/ [1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1],  // gap @ c3 & c12
+  /*r13*/ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // bottom hallway
+  /*r14*/ [1, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 1],  // bottle(3,14) gift box(8,14)
+  /*r15*/ [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+];
+// bottles: (4,3)(11,3)(7,5)(4,11)(11,11)(3,14) = 6   gift box: (8,14)
+
+// ── STAGE 2: Runaway Toys! ──────────────────────────────────
+// Same nursery layout, but the toys have escaped the toy box:
+// a wind-up teddy patrols the upper room, a rubber ducky bounces
+// along the hallway, and a toy train circles the lower room.
+const _R2_MAP = [
+  /*r0*/  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  /*r1*/  [1, 0,23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // hint @ (2,1)
+  /*r2*/  [1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1],
+  /*r3*/  [1, 1, 1, 0, 2, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1],  // bottles @ (4,3)(11,3)
+  /*r4*/  [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],  // upper playroom (teddy)
+  /*r5*/  [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+  /*r6*/  [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1],
+  /*r7*/  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // hallway (ducky)
+  /*r8*/  [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1],
+  /*r9*/  [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],  // lower playroom (toy train)
+  /*r10*/ [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+  /*r11*/ [1, 1, 1, 0, 2, 0, 0, 0, 0, 0, 0, 2, 0, 1, 1, 1],  // bottles @ (4,11)(11,11)
+  /*r12*/ [1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1],
+  /*r13*/ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+  /*r14*/ [1, 0, 0, 2, 0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 1],  // bottles(3,14)(12,14) gift(8,14)
+  /*r15*/ [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+];
+// bottles: (4,3)(11,3)(4,11)(11,11)(3,14)(12,14) = 6   gift box: (8,14)
+
+// ── STAGE 3: The Stork's Secret ─────────────────────────────
+// The big finale.  A BLUE key opens the blue door; a PINK key
+// opens the pink door.  You need both — pink or blue, which will
+// it be?  Bouncing duckies and a crawling baby doll stand between
+// Shmo and the stork's secret gift box.
+const _R3_MAP = [
+  /*r0*/  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  /*r1*/  [1, 0,23, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // hint @ (2,1), BLUE key @ (6,1)
+  /*r2*/  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+  /*r3*/  [1, 0, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 2, 1, 0, 1],  // bottles @ (3,3)(12,3)
+  /*r4*/  [1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1],
+  /*r5*/  [1, 1, 1, 1, 1, 1,13, 1, 1, 1, 1, 1, 1, 1, 1, 1],  // BLUE door @ (6,5)
+  /*r6*/  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // ducky bounces here
+  /*r7*/  [1, 0, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 2, 1, 0, 1],  // bottles @ (3,7)(12,7)
+  /*r8*/  [1, 0, 1, 0, 1, 0, 0,10, 0, 0, 0, 1, 0, 1, 0, 1],  // PINK key @ (7,8)
+  /*r9*/  [1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1],  // teddy patrols here
+  /*r10*/ [1, 1, 1, 1, 1, 1,14, 1, 1, 1, 1, 1, 1, 1, 1, 1],  // PINK door @ (6,10)
+  /*r11*/ [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  // ducky bounces here
+  /*r12*/ [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1],
+  /*r13*/ [1, 0, 1, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 1, 0, 1],  // STORK'S GIFT @ (7,13)
+  /*r14*/ [1, 0, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 1],  // bottles @ (5,14)(9,14)
+  /*r15*/ [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+];
+// bottles: (3,3)(12,3)(3,7)(12,7)(5,14)(9,14) = 6   gift box: (7,13)
+
+// ── Assemble the reveal level set ───────────────────────────
+
+const REVEAL_LEVELS = [
+  {
+    number: 1,
+    title:  'Welcome to the Nursery',
+    hint:   'Welcome to the Nursery, Big Brother!  Collect every baby bottle 🍼 then open the mystery gift box 🎁!',
+    timeLimit: 0,
+    map:    _copyMap(_R1_MAP),
+    playerStart: { x: 1, y: 1 },
+    entities: [],
+    width:  16,
+    height: 16,
+  },
+  {
+    number: 2,
+    title:  'Runaway Toys!',
+    hint:   'Uh-oh — the toys escaped the toy box!  Dodge the teddy 🧸, the ducky 🦆 and the toy train 🚂 while you grab the bottles!',
+    timeLimit: 0,
+    map:    _copyMap(_R2_MAP),
+    playerStart: { x: 1, y: 1 },
+    entities: [
+      { type: E.BUG,      x: 7, y: 4,  dir: D.N },  // wind-up teddy — upper playroom
+      { type: E.BALL,     x: 7, y: 7,  dir: D.E },  // bouncing ducky — hallway
+      { type: E.FIREBALL, x: 7, y: 10, dir: D.S },  // toy train — lower playroom
+    ],
+    width:  16,
+    height: 16,
+  },
+  {
+    number: 3,
+    title:  "The Stork's Secret",
+    hint:   'Pink or blue?  Grab BOTH keys to unlock the doors and reach the stork’s secret gift box... the answer is inside!',
+    timeLimit: 0,
+    map:    _copyMap(_R3_MAP),
+    playerStart: { x: 1, y: 1 },
+    entities: [
+      { type: E.BALL, x: 8, y: 6,  dir: D.E },  // bouncing ducky — middle hallway
+      { type: E.BUG,  x: 8, y: 9,  dir: D.E },  // wind-up teddy — middle chamber
+      { type: E.BALL, x: 9, y: 11, dir: D.W },  // bouncing ducky — bottom hallway
+    ],
+    width:  16,
+    height: 16,
+  },
+];
+
+// ────────────────────────────────────────────────────────────
+//  REVEAL RENDERER — pastel nursery theme
+// ────────────────────────────────────────────────────────────
+
+const REVEAL_COLORS = {
+  floorPink:  '#ffeef5',   // soft blush
+  floorBlue:  '#eaf4ff',   // soft sky
+  blockPink:  '#ffb6d9',   // pink baby block
+  blockPinkD: '#e08ab4',   // pink block shadow
+  blockBlue:  '#a8d4ff',   // blue baby block
+  blockBlueD: '#7fadde',   // blue block shadow
+  bottleRing: '#ff8fb3',   // bottle glow ring
+  giftOpen:   '#ff9ec4',   // unwrappable gift box
+  giftLocked: '#b8b0c0',   // still-wrapped (locked) gift box
+  ribbonGold: '#ffd700',
+  ribbonGrey: '#8a8494',
+};
+
+// Toy stand-ins for the regular enemies
+const REVEAL_ENEMY_EMOJI = {
+  [E.BUG]:      '🧸',  // wind-up teddy
+  [E.FIREBALL]: '🚂',  // toy train
+  [E.BALL]:     '🦆',  // rubber ducky
+  [E.TANK]:     '🚗',  // toy car
+  [E.GLIDER]:   '🪁',  // kite
+  [E.TEETH]:    '👶',  // crawling baby doll
+  [E.WALKER]:   '🎁',  // mystery present
+};
+
+// Letters scattered across the wall blocks
+const REVEAL_BLOCK_LETTERS = 'BABY?';
+
+class RendererReveal extends Renderer {
+  constructor(canvas) {
+    super(canvas);
+    // Pink key/door instead of red — pink or blue, which will it be?
+    this.keyColors  = { ...KEY_COLORS,  [T.KEY_RED]:  '#ff69b4' };
+    this.doorColors = { ...DOOR_COLORS, [T.DOOR_RED]: '#ff69b4' };
+    this._mapX = 0;
+    this._mapY = 0;
+  }
+
+  // Stash map coordinates so floor/wall patterns stay fixed to the
+  // map instead of shifting with the camera.
+  _drawTile(ctx, tile, sx, sy, chipsLeft, mx, my, game) {
+    this._mapX = mx;
+    this._mapY = my;
+    super._drawTile(ctx, tile, sx, sy, chipsLeft, mx, my, game);
+  }
+
+  // Soft pink/blue checkerboard floor — the big question underfoot!
+  _drawFloor(ctx, sx, sy) {
+    const ts = this.ts;
+    const pink = (this._mapX + this._mapY) % 2 === 0;
+    ctx.fillStyle = pink ? REVEAL_COLORS.floorPink : REVEAL_COLORS.floorBlue;
+    ctx.fillRect(sx, sy, ts, ts);
+    ctx.strokeStyle = 'rgba(180,150,180,0.25)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(sx + 0.5, sy + 0.5, ts - 1, ts - 1);
+  }
+
+  // Walls are pastel alphabet baby blocks spelling B-A-B-Y
+  _drawWall(ctx, sx, sy) {
+    const ts = this.ts;
+    const mx = this._mapX, my = this._mapY;
+    const pink = (mx + my) % 2 === 0;
+    const base   = pink ? REVEAL_COLORS.blockPink  : REVEAL_COLORS.blockBlue;
+    const shadow = pink ? REVEAL_COLORS.blockPinkD : REVEAL_COLORS.blockBlueD;
+    // Block body
+    ctx.fillStyle = base;
+    ctx.fillRect(sx, sy, ts, ts);
+    // Bevel — light top/left, dark bottom/right
+    ctx.fillStyle = 'rgba(255,255,255,0.55)';
+    ctx.fillRect(sx, sy, ts, 4);
+    ctx.fillRect(sx, sy, 4, ts);
+    ctx.fillStyle = shadow;
+    ctx.fillRect(sx, sy + ts - 4, ts, 4);
+    ctx.fillRect(sx + ts - 4, sy, 4, ts);
+    // Inner frame
+    ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(sx + 7, sy + 7, ts - 14, ts - 14);
+    // Letter
+    const letter = REVEAL_BLOCK_LETTERS[(mx * 3 + my * 7) % REVEAL_BLOCK_LETTERS.length];
+    ctx.fillStyle = shadow;
+    ctx.font = `bold ${ts - 18}px 'Courier New', monospace`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(letter, sx + ts / 2, sy + ts / 2 + 1);
+  }
+
+  // Chips become baby bottles
+  _drawChip(ctx, sx, sy) {
+    const ts = this.ts;
+    const cx = sx + ts / 2, cy = sy + ts / 2;
+    // Soft glow pad
+    ctx.fillStyle = 'rgba(255,255,255,0.75)';
+    ctx.beginPath();
+    ctx.arc(cx, cy, ts / 2 - 5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = REVEAL_COLORS.bottleRing;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(cx, cy, ts / 2 - 5, 0, Math.PI * 2);
+    ctx.stroke();
+    // Bottle
+    ctx.font = `${ts - 14}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('🍼', cx, cy + 1);
+  }
+
+  // The exit is the stork's mystery gift box
+  _drawExit(ctx, sx, sy, open) {
+    const ts = this.ts;
+    const box    = open ? REVEAL_COLORS.giftOpen   : REVEAL_COLORS.giftLocked;
+    const ribbon = open ? REVEAL_COLORS.ribbonGold : REVEAL_COLORS.ribbonGrey;
+    // Box body
+    ctx.fillStyle = box;
+    ctx.fillRect(sx + 4, sy + 12, ts - 8, ts - 16);
+    // Lid
+    ctx.fillRect(sx + 2, sy + 6, ts - 4, 8);
+    // Vertical ribbon
+    ctx.fillStyle = ribbon;
+    ctx.fillRect(sx + ts / 2 - 3, sy + 6, 6, ts - 10);
+    // Horizontal ribbon
+    ctx.fillRect(sx + 4, sy + ts / 2 + 2, ts - 8, 5);
+    // Bow on top
+    ctx.font = `${Math.floor(ts / 2.5)}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('🎀', sx + ts / 2, sy + 7);
+    // Question mark
+    ctx.fillStyle = open ? '#ffffff' : '#6a6474';
+    ctx.font = `bold ${Math.floor(ts / 2)}px 'Courier New', monospace`;
+    ctx.fillText('?', sx + ts / 2, sy + ts * 0.68);
+  }
+
+  // Runaway toys instead of enemies
+  _drawEnemy(ctx, ent, sx, sy) {
+    const ts = this.ts;
+    // Soft shadow under the toy
+    ctx.fillStyle = 'rgba(120,80,120,0.2)';
+    ctx.beginPath();
+    ctx.ellipse(sx + ts / 2, sy + ts - 6, ts / 3, 4, 0, 0, Math.PI * 2);
+    ctx.fill();
+    // The toy itself
+    ctx.font = `${ts - 8}px serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(REVEAL_ENEMY_EMOJI[ent.type] || '🎁', sx + ts / 2, sy + ts / 2);
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+//  CONFETTI — canvas particle shower for the big moment
+// ────────────────────────────────────────────────────────────
+
+class ConfettiShow {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx    = canvas.getContext('2d');
+    this.rafId  = null;
+    this.particles = [];
+    this.colors = ['#ff69b4', '#ffb6d9', '#ff8fab', '#ff1493', '#ffd700', '#ffffff', '#ffc0cb'];
+    this.emoji  = ['💖', '🎀', '👶', '🍼', '💕'];
+  }
+
+  _resize() {
+    this.canvas.width  = window.innerWidth;
+    this.canvas.height = window.innerHeight;
+  }
+
+  _spawn(burst) {
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+    for (let i = 0; i < 160; i++) {
+      this.particles.push({
+        x:    Math.random() * w,
+        y:    burst ? h / 2 + (Math.random() - 0.5) * 200 : -Math.random() * h,
+        vx:   (Math.random() - 0.5) * (burst ? 14 : 2),
+        vy:   burst ? (Math.random() - 0.9) * 12 : 2 + Math.random() * 3,
+        rot:  Math.random() * Math.PI * 2,
+        vrot: (Math.random() - 0.5) * 0.25,
+        size: 6 + Math.random() * 10,
+        color: this.colors[Math.floor(Math.random() * this.colors.length)],
+        emoji: Math.random() < 0.18
+          ? this.emoji[Math.floor(Math.random() * this.emoji.length)]
+          : null,
+      });
+    }
+  }
+
+  start() {
+    this._resize();
+    this._onResize = () => this._resize();
+    window.addEventListener('resize', this._onResize);
+    this.particles = [];
+    this._spawn(true);    // initial burst from the centre (the balloon pop!)
+    this._spawn(false);   // plus a steady rain from above
+    const loop = () => {
+      this._step();
+      this.rafId = requestAnimationFrame(loop);
+    };
+    this.rafId = requestAnimationFrame(loop);
+  }
+
+  _step() {
+    const ctx = this.ctx;
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    for (const p of this.particles) {
+      p.vy  += 0.12;                       // gravity
+      p.vy   = Math.min(p.vy, 5);          // terminal velocity
+      p.vx  *= 0.99;
+      p.x   += p.vx + Math.sin(p.y / 40);  // gentle sway
+      p.y   += p.vy;
+      p.rot += p.vrot;
+      // Recycle particles that fall off the bottom
+      if (p.y > h + 30) {
+        p.y  = -20;
+        p.x  = Math.random() * w;
+        p.vy = 2 + Math.random() * 3;
+        p.vx = (Math.random() - 0.5) * 2;
+      }
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rot);
+      if (p.emoji) {
+        ctx.font = `${p.size + 8}px serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(p.emoji, 0, 0);
+      } else {
+        ctx.fillStyle = p.color;
+        ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+      }
+      ctx.restore();
+    }
+  }
+
+  stop() {
+    if (this.rafId) cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+    window.removeEventListener('resize', this._onResize);
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.particles = [];
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+//  THE BIG MOMENT — countdown → balloon pop → the reveal!
+// ────────────────────────────────────────────────────────────
+
+const BALLOON_TAPS_TO_POP = 5;
+
+// Tears down the in-flight celebration (pending timers, listeners, confetti)
+// so a new one can start clean.  Set by startRevealCelebration.
+let _celebrationCleanup = null;
+
+function startRevealCelebration(game) {
+  // The celebration runs its own animations — halt the game loop so it
+  // stops drawing the (now hidden) game screen every frame.
+  game.running = false;
+  if (game.rafId) { cancelAnimationFrame(game.rafId); game.rafId = null; }
+
+  // If a previous celebration is somehow still in flight, tear it down first.
+  if (_celebrationCleanup) _celebrationCleanup();
+
+  const show = id => {
+    document.querySelectorAll('#reveal-screen .reveal-phase').forEach(el => el.classList.add('hidden'));
+    document.getElementById(id).classList.remove('hidden');
+  };
+
+  const balloon     = document.getElementById('reveal-balloon');
+  const homeBtn     = document.getElementById('reveal-home-btn');
+  const countdownEl = document.getElementById('reveal-countdown');
+  const timers      = [];
+
+  const cleanup = () => {
+    timers.forEach(clearTimeout);
+    balloon.removeEventListener('pointerdown', onTap);
+    homeBtn.removeEventListener('click', onHome);
+    if (game._confetti) { game._confetti.stop(); game._confetti = null; }
+    _celebrationCleanup = null;
+  };
+  _celebrationCleanup = cleanup;
+
+  game._showScreen('reveal-screen');
+  show('reveal-intro');
+  countdownEl.textContent = '';
+
+  // Phase 1 — countdown: 3... 2... 1...
+  let count = 3;
+  const tickCountdown = () => {
+    if (count > 0) {
+      countdownEl.textContent = count;
+      // Restart the pop-in animation
+      countdownEl.classList.remove('count-pop');
+      void countdownEl.offsetWidth;
+      countdownEl.classList.add('count-pop');
+      game.audio.countdownBeep();
+      count--;
+      timers.push(setTimeout(tickCountdown, 1000));
+    } else {
+      startBalloonPhase();
+    }
+  };
+  timers.push(setTimeout(tickCountdown, 1600));
+
+  // Phase 2 — inflate the mystery balloon by tapping it
+  let taps = 0;
+  let popped = false;
+
+  const onTap = (e) => {
+    e.preventDefault();
+    if (popped) return;
+    taps++;
+    game.audio.balloonTap(taps);
+    balloon.style.transform = `scale(${1 + taps * 0.22})`;
+    if (taps >= BALLOON_TAPS_TO_POP) {
+      popped = true;
+      popBalloon();
+    }
+  };
+
+  // "Back to title" — tear everything down and hand control back to the game.
+  const onHome = () => {
+    cleanup();
+    game._returnToTitle();
+  };
+  homeBtn.addEventListener('click', onHome);
+
+  function startBalloonPhase() {
+    taps = 0;
+    popped = false;
+    balloon.style.transform = 'scale(1)';
+    balloon.classList.remove('popped');
+    show('reveal-balloon-phase');
+    balloon.addEventListener('pointerdown', onTap);
+  }
+
+  // Phase 3 — POP!  Confetti + the big secret
+  function popBalloon() {
+    balloon.removeEventListener('pointerdown', onTap);
+    game.audio.balloonPop();
+    balloon.classList.add('popped');
+    timers.push(setTimeout(() => {
+      show('reveal-final-phase');
+      game.audio.revealFanfare();
+      // Pink confetti everywhere!
+      game._confetti = new ConfettiShow(document.getElementById('confetti-canvas'));
+      game._confetti.start();
+    }, 450));
+  }
+}


### PR DESCRIPTION
## What's new

A special surprise game mode, **The Reveal**, built for a gender-reveal moment. The Big Brother plays through three baby-themed stages — and when he beats the last one, the game tells him the secret: **"You're going to have a BABY SISTER!"** 💖

### The experience

1. **Title screen** — a new pulsing pink/blue **🍼 THE REVEAL 🎀** button ("A special surprise mission for the Big Brother...")
2. **Stage 1: Welcome to the Nursery** — learn the goal: collect every baby bottle 🍼, then open the mystery gift box 🎁
3. **Stage 2: Runaway Toys!** — dodge the wind-up teddy 🧸, bouncing rubber ducky 🦆, and toy train 🚂
4. **Stage 3: The Stork's Secret** — a *pink-or-blue* key puzzle: grab BOTH keys to unlock the stork's gift box
5. **The big moment** — 3‑2‑1 countdown → tap-to-pop the mystery balloon → pink confetti shower + **"IT'S A GIRL! You're going to have a BABY SISTER! Congratulations, Big Brother!"** with a triumphant fanfare

### Implementation

- **`js/reveal.js`** (new): `REVEAL_LEVELS` (3 stages), `RendererReveal` (pastel pink/blue checkerboard floors, B‑A‑B‑Y alphabet-block walls, bottle/gift-box/toy sprites, pink key & door), `ConfettiShow` particle system, and the celebration sequence with full timer/listener cleanup
- **`js/game.js`**: `levelSet`/`revealMode` support, themed HUD labels & messages, celebration sounds in `AudioManager`, instance-level key/door palettes on `Renderer`, shared `_returnToTitle()` teardown
- **`index.html` / `css/style.css`**: reveal button, celebration screens, balloon/confetti/headline animations
- **Drive-by fix**: scoped `#game-screen` → `#game-screen.active` in the desktop media query — previously the game canvas stayed visible behind *every* other screen on desktop (pre-existing specificity bug)

### Verification

- ✅ BFS solvability check: every bottle and the gift box reachable in all 3 stages (honoring key/door rules)
- ✅ Scripted end-to-end playthroughs of all 3 stages via the real `Game` logic → `won === true`
- ✅ Final-stage win triggers the celebration; classic-mode regression playthroughs unaffected
- ✅ Playwright browser run of the full flow (title → stages → countdown → balloon pop → reveal → back to title → replay) with zero console errors
- ✅ Code-reviewed (7-angle review); fixed: game loop now halts during the celebration, celebration timers/listeners have a cleanup path, shared title teardown, no `!important` CSS

https://claude.ai/code/session_01Fqii6mqFWNCuFHnQJHMYBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fqii6mqFWNCuFHnQJHMYBr)_